### PR TITLE
support HttpOnly and SameSite in Plugin::Session::State::Cookie

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'Plack', '0.9910';
 requires 'Plack::Request::WithEncoding', '0.10';
 requires 'Plack::Response';
+requires 'Cookie::Baker', '0.11';
 requires 'Mouse',       '1.0';
 requires 'Try::Tiny',   '0.02';
 requires 'Path::Class', '0.16';

--- a/lib/Ark/Plugin/Session/State/Cookie.pm
+++ b/lib/Ark/Plugin/Session/State/Cookie.pm
@@ -57,6 +57,26 @@ has cookie_secure => (
     },
 );
 
+has cookie_httponly => (
+    is      => 'rw',
+    isa     => 'Bool',
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        $self->class_config->{cookie_httponly} || 0;
+    },
+);
+
+has cookie_samesite => (
+    is      => 'rw',
+    isa     => 'Str',
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        $self->class_config->{cookie_samesite} || '';
+    },
+);
+
 has cookie_remove_marker => (
     is      => 'rw',
     isa     => 'Bool',
@@ -131,11 +151,13 @@ sub make_cookie {
     my ($self, $sid, $attrs) = @_;
 
     my $cookie = {
-        value   => $sid,
-        expires => $self->cookie_expires,
-        secure  => $self->cookie_secure,
-        $self->cookie_domain ? (domain => $self->cookie_domain) : (),
-        $self->cookie_path   ? (path   => $self->cookie_path) : (),
+        value    => $sid,
+        expires  => $self->cookie_expires,
+        secure   => $self->cookie_secure,
+        httponly => $self->cookie_httponly,
+        $self->cookie_samesite ? (samesite => $self->cookie_samesite) : (),
+        $self->cookie_domain   ? (domain => $self->cookie_domain) : (),
+        $self->cookie_path     ? (path   => $self->cookie_path) : (),
         %{ $attrs || {} },
     };
 }

--- a/t/plugin_session_state_cookie.t
+++ b/t/plugin_session_state_cookie.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package TestApp;
+    use Ark;
+
+    use_plugins qw/
+        Session
+        Session::State::Cookie
+        Session::Store::Memory
+        /;
+
+    conf 'Plugin::Session::State::Cookie' => {
+        cookie_secure   => 1,
+        cookie_httponly => 1,
+        cookie_samesite => 'None',
+    };
+
+    package TestApp::Controller::Root;
+    use Ark 'Controller';
+
+    has '+namespace' => default => '';
+
+    sub test_set :Local {
+        my ($self, $c) = @_;
+        $c->session->set('test', 'dummy');
+    }
+}
+
+
+use Ark::Test 'TestApp',
+    components       => [qw/Controller::Root/],
+    reuse_connection => 1;
+
+{
+    my $res = request(GET => '/test_set');
+    like( $res->header('Set-Cookie'), qr/secure/, 'secure is true');
+    like( $res->header('Set-Cookie'), qr/HttpOnly/, 'HttpOnly is true');
+    like( $res->header('Set-Cookie'), qr/SameSite=None;/, 'SameSite is None');
+}
+done_testing;


### PR DESCRIPTION
In this Pull Request, add a feature to set attributes `HttpOnly` and `SameSite` on the session cookie.

Also specified versioned Cookie::Baker on a cpanfile for using `SameSite=None`.

https://github.com/kazeburo/Cookie-Baker/pull/15